### PR TITLE
chore: Adds archive message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Private Endpoint Terraform Module
 
-# This module has been deprecated
-
-This repository is no longer maintained. Its functionality has been superseded by the [MongoDB Atlas AWS Module](https://registry.terraform.io/modules/terraform-mongodbatlas-modules/atlas-aws/mongodbatlas/latest) (`terraform-mongodbatlas-modules/atlas-aws/mongodbatlas`), which provides PrivateLink support along with additional AWS integrations including encryption at rest with AWS KMS, cloud provider access, and backup export to S3.
+> **Archived:** This repository is no longer maintained. Use the [MongoDB Atlas AWS module](https://github.com/terraform-mongodbatlas-modules/terraform-mongodbatlas-atlas-aws) from the [terraform-mongodbatlas-modules](https://github.com/terraform-mongodbatlas-modules/) organization instead. For up-to-date Terraform examples and reference implementations, see [atlas-examples](https://github.com/terraform-mongodbatlas-modules/atlas-examples).
 
 ## Migration
 

--- a/examples/aws-private-link-cluster-geosharded/README.md
+++ b/examples/aws-private-link-cluster-geosharded/README.md
@@ -1,8 +1,6 @@
 # private-endpoint-aws-private-link-cluster - enable private endpoint for a geosharded cluster
 
-# This module has been deprecated
-
-This repository is no longer maintained. Its functionality has been superseded by the [MongoDB Atlas AWS Module](https://registry.terraform.io/modules/terraform-mongodbatlas-modules/atlas-aws/mongodbatlas/latest) (`terraform-mongodbatlas-modules/atlas-aws/mongodbatlas`), which provides PrivateLink support along with additional AWS integrations including encryption at rest with AWS KMS, cloud provider access, and backup export to S3.
+> **Archived:** This repository is no longer maintained. Use the [MongoDB Atlas AWS module](https://github.com/terraform-mongodbatlas-modules/terraform-mongodbatlas-atlas-aws) from the [terraform-mongodbatlas-modules](https://github.com/terraform-mongodbatlas-modules/) organization instead. For up-to-date Terraform examples and reference implementations, see [atlas-examples](https://github.com/terraform-mongodbatlas-modules/atlas-examples).
 
 ## Migration
 

--- a/examples/aws-private-link-cluster-single-region/README.md
+++ b/examples/aws-private-link-cluster-single-region/README.md
@@ -1,8 +1,6 @@
 # private-endpoint-aws-private-link-cluster - enable private endpoint for a single region cluster
 
-# This module has been deprecated
-
-This repository is no longer maintained. Its functionality has been superseded by the [MongoDB Atlas AWS Module](https://registry.terraform.io/modules/terraform-mongodbatlas-modules/atlas-aws/mongodbatlas/latest) (`terraform-mongodbatlas-modules/atlas-aws/mongodbatlas`), which provides PrivateLink support along with additional AWS integrations including encryption at rest with AWS KMS, cloud provider access, and backup export to S3.
+> **Archived:** This repository is no longer maintained. Use the [MongoDB Atlas AWS module](https://github.com/terraform-mongodbatlas-modules/terraform-mongodbatlas-atlas-aws) from the [terraform-mongodbatlas-modules](https://github.com/terraform-mongodbatlas-modules/) organization instead. For up-to-date Terraform examples and reference implementations, see [atlas-examples](https://github.com/terraform-mongodbatlas-modules/atlas-examples).
 
 ## Migration
 

--- a/modules/aws-private-link-cluster/README.md
+++ b/modules/aws-private-link-cluster/README.md
@@ -1,5 +1,7 @@
 # AWS Private Link Cluster Terraform Submodule
 
+> **Archived:** This repository is no longer maintained. Use the [MongoDB Atlas AWS module](https://github.com/terraform-mongodbatlas-modules/terraform-mongodbatlas-atlas-aws) from the [terraform-mongodbatlas-modules](https://github.com/terraform-mongodbatlas-modules/) organization instead. For up-to-date Terraform examples and reference implementations, see [atlas-examples](https://github.com/terraform-mongodbatlas-modules/atlas-examples).
+
 This Terraform submodule sets up a [private connection](https://www.mongodb.com/docs/atlas/security-private-endpoint/#-optional--regionalized-private-endpoints-for-multi-region-sharded-clusters) to a [MongoDB Atlas Cluster](https://www.mongodb.com/resources/products/fundamentals/mongodb-cluster-setup) utilizing [Amazon Virtual Private Cloud (aws vpc)](https://docs.aws.amazon.com/vpc/latest/userguide/what-is-amazon-vpc.html). The cluster can be either single region or geosharded (multiple regions).
 
 It creates the following resources:


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-408816

Standardizes the archived notice to the blockquote format used across legacy module repos. Replaces the previous `# This module has been deprecated` heading and prose paragraph where present; adds the blockquote to the aws-private-link-cluster submodule README. Keeps the existing Migration section and links to atlas-aws.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] Documentation fix/enhancement
